### PR TITLE
pydantic-extra-types 2.10.5: rebuild-py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,11 +39,6 @@ test:
     - tests
   imports:
     - pydantic_extra_types
-  commands:
-    - pip check
-    # missing python-ulid
-    - pytest -v --ignore=tests/test_ulid.py --ignore=tests/test_json_schema.py --ignore=tests/test_pendulum.py tests  # [py==314]
-    - pytest -v --ignore=tests/test_ulid.py --ignore=tests/test_json_schema.py tests  # [py<314]
   requires:
     - pytest
     - pip
@@ -54,6 +49,13 @@ test:
     - pendulum  # [py<314]
     - pymongo
     - pycountry
+  commands:
+    - pip check
+    # 1. §missing python-ulid
+    # 2. test_json_schema is skipped because of AssertionError: assert {'properties'...pe': 'object'} == {'properties'...pe': 'object'}.
+    # 3. test_pendulum_dt is skipped because it fails on py314 due to pendulum 3.1.0 not supporting py314.
+    - pytest -v --ignore=tests/test_ulid.py --ignore=tests/test_json_schema.py --ignore=tests/test_pendulum_dt.py -k "not test_json_schema" tests  # [py==314]
+    - pytest -v --ignore=tests/test_ulid.py --ignore=tests/test_json_schema.py tests  # [py<314]
 
 about:
   home: https://github.com/pydantic/pydantic-extra-types

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ test:
     - pycountry
   commands:
     - pip check
-    # 1. §missing python-ulid
+    # 1. missing python-ulid
     # 2. test_json_schema is skipped because of AssertionError: assert {'properties'...pe': 'object'} == {'properties'...pe': 'object'}.
     # 3. test_pendulum_dt is skipped because it fails on py314 due to pendulum 3.1.0 not supporting py314.
     - pytest -v --ignore=tests/test_ulid.py --ignore=tests/test_json_schema.py --ignore=tests/test_pendulum_dt.py -k "not test_json_schema" tests  # [py==314]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - pytz >=2024.1
     - python-tzdata >=2024.1
     - tzdata >=2024.1
-    - cron-converter >=1.2.2"
+    - cron-converter >=1.2.2
 
 test:
   source_files:
@@ -54,10 +54,9 @@ test:
   commands:
     - pip check
     # 1. missing python-ulid
-    # 2. test_json_schema is skipped because of AssertionError: assert {'properties'...pe': 'object'} == {'properties'...pe': 'object'}.
-    # 3. test_pendulum_dt is skipped because it fails on py314 due to pendulum 3.1.0 not supporting py314.
-    - pytest -v --ignore=tests/test_ulid.py --ignore=tests/test_json_schema.py --ignore=tests/test_pendulum_dt.py -k "not test_json_schema" tests  # [py==314]
-    - pytest -v --ignore=tests/test_ulid.py --ignore=tests/test_json_schema.py tests  # [py<314]
+    # 2. test_pendulum_dt is skipped because it fails on py314 due to pendulum 3.1.0 not supporting py314.
+    - pytest -v --ignore=tests/test_ulid.py --ignore=tests/test_pendulum_dt.py tests  # [py==314]
+    - pytest -v --ignore=tests/test_ulid.py tests  # [py<314]
 
 about:
   home: https://github.com/pydantic/pydantic-extra-types

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,9 +54,10 @@ test:
   commands:
     - pip check
     # 1. missing python-ulid
-    # 2. test_pendulum_dt is skipped because it fails on py314 due to pendulum 3.1.0 not supporting py314.
-    - pytest -v --ignore=tests/test_ulid.py --ignore=tests/test_pendulum_dt.py tests  # [py==314]
-    - pytest -v --ignore=tests/test_ulid.py tests  # [py<314]
+    # 2. test_json_schema and test_cron are skipped because cron-converter isn't available on the main channel.
+    - pytest -v --ignore=tests/test_ulid.py --ignore=tests/test_json_schema.py --ignore=tests/test_cron.py tests  # [py<314]
+    # test_pendulum_dt is skipped because it fails on py314 due to pendulum 3.1.0 not supporting py314.
+    - pytest -v --ignore=tests/test_ulid.py --ignore=tests/test_json_schema.py --ignore=tests/test_cron.py --ignore=tests/test_pendulum_dt.py tests  # [py==314]
 
 about:
   home: https://github.com/pydantic/pydantic-extra-types

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pydantic-extra-types" %}
-{% set version = "2.10.5" %}
+{% set version = "2.11.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 1dcfa2c0cf741a422f088e0dbb4690e7bfadaaf050da3d6f80d6c3cf58a2bad8
+  sha256: 4e9991959d045b75feb775683437a97991d02c138e00b59176571db9ce634f0e
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<38]
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -29,10 +29,12 @@ requirements:
     - pycountry >=23
     - python-ulid >=1,<2  # [py<39]
     - python-ulid >=1,<4  # [py>=39]
-    - semver >=3.0.2,<3.1.dev0
+    - semver >=3.0.2,<3.1.0
     - pymongo >=4.0.0,<5.0.0
     - pytz >=2024.1
     - python-tzdata >=2024.1
+    - tzdata >=2024.1
+    - cron-converter >=1.2.2"
 
 test:
   source_files:
@@ -59,13 +61,13 @@ test:
 
 about:
   home: https://github.com/pydantic/pydantic-extra-types
-  summary: Extra Pydantic types.
   dev_url: https://github.com/pydantic/pydantic-extra-types
+  doc_url: https://docs.pydantic.dev
+  summary: Extra Pydantic types.
+  description: A place for pydantic types that probably shouldn't exist in the main pydantic lib.
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  description: "A place for pydantic types that probably shouldn't exist in the main pydantic lib."
-  doc_url: https://docs.pydantic.dev
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1dcfa2c0cf741a422f088e0dbb4690e7bfadaaf050da3d6f80d6c3cf58a2bad8
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<38]
 
@@ -42,14 +42,16 @@ test:
   commands:
     - pip check
     # missing python-ulid
-    - pytest -v --ignore=tests/test_ulid.py --ignore=tests/test_json_schema.py tests
+    - pytest -v --ignore=tests/test_ulid.py --ignore=tests/test_json_schema.py --ignore=tests/test_pendulum.py tests  # [py==314]
+    - pytest -v --ignore=tests/test_ulid.py --ignore=tests/test_json_schema.py tests  # [py<314]
   requires:
     - pytest
     - pip
     - pytz
     - semver
     - phonenumbers
-    - pendulum
+    # pendulum 3.1.0 doesn't support py314. Re-enable when pendulum 3.2.0+ is released.
+    - pendulum  # [py<314]
     - pymongo
     - pycountry
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-11873) 
- [Upstream repository](https://github.com/pydantic/pydantic-extra-types/tree/v2.10.5)

### Explanation of changes:

- Skip tests that depend on pendulum, which doesn't support py314 yet.

### Notes:

- Rebuilding for fastapi https://github.com/AnacondaRecipes/fastapi-feedstock/pull/8